### PR TITLE
Fixed windows path issue

### DIFF
--- a/demo/coffee-go/Makefile
+++ b/demo/coffee-go/Makefile
@@ -37,8 +37,7 @@ sh-unix:
 
 bat-windows:
 	echo '@ECHO OFF' > $(BAT)
-	echo 'SET mypath=%~dp0' >> $(BAT)
-	echo 'start /B /WAIT %mypath:~0,-1%/windows/main.exe' >> $(BAT)
+	echo 'start /B /WAIT windows/main.exe' >> $(BAT)
 
 docker:
 	cp Dockerfile set_umask.sh $(BIN_FOLDER)

--- a/demo/coffee-go/build.bat
+++ b/demo/coffee-go/build.bat
@@ -30,8 +30,7 @@ SET SH_FILE=%BIN_FOLDER%\run.sh
     SET GOARCH=amd64
     %GOBUILD% -tags release -o %DIST_WIN_DIR%\%BIN_WIN% %CMD_PATH%
     echo @ECHO OFF > %BAT_FILE%
-    echo SET mypath=%%~dp0 >> %BAT_FILE%
-    echo start /B /WAIT %%mypath:~0,-1%%/windows/main.exe >> %BAT_FILE%
+    echo start /B /WAIT windows/main.exe >> %BAT_FILE%
     GOTO DONE
 
 :linux

--- a/demo/coffee-node/build.bat
+++ b/demo/coffee-node/build.bat
@@ -17,8 +17,7 @@ SET SH_FILE=%BIN_FOLDER%\run.sh
 
 :BAT_WINDOWS
     echo @ECHO OFF > %BAT_FILE%
-    echo SET mypath=%%~dp0 >> %BAT_FILE%
-    echo start /B /WAIT node %%mypath:~0,-1%%/main.js >> %BAT_FILE%
+    echo start /B /WAIT node main.js >> %BAT_FILE%
 
 :SH_LINUX
     echo node "$(dirname "$0")"/main.js > %SH_FILE%

--- a/demo/coffee-python/build.bat
+++ b/demo/coffee-python/build.bat
@@ -14,8 +14,7 @@ SET SH_FILE=%BIN_FOLDER%\run.sh
 
 :BAT_WINDOWS
     echo @ECHO OFF > %BAT_FILE%
-    echo SET mypath=%%~dp0 >> %BAT_FILE%
-    echo start /B /WAIT python %%mypath:~0,-1%%/main.py >> %BAT_FILE%
+    echo start /B /WAIT python main.py >> %BAT_FILE%
 
 :SH_LINUX
     echo python "$(dirname "$0")"/main.py > %SH_FILE%

--- a/demo/hello-world/Makefile
+++ b/demo/hello-world/Makefile
@@ -37,8 +37,7 @@ sh-unix:
 
 bat-windows:
 	echo '@ECHO OFF' > $(BAT)
-	echo 'SET mypath=%~dp0' >> $(BAT)
-	echo 'start /B /WAIT %mypath:~0,-1%/windows/main.exe' >> $(BAT)
+	echo 'start /B /WAIT windows/main.exe' >> $(BAT)
 
 docker:
 	cp Dockerfile set_umask.sh $(BIN_FOLDER)

--- a/demo/hello-world/build.bat
+++ b/demo/hello-world/build.bat
@@ -30,8 +30,7 @@ SET SH_FILE=%BIN_FOLDER%\run.sh
     SET GOARCH=amd64
     %GOBUILD% -tags release -o %DIST_WIN_DIR%\%BIN_WIN% %CMD_PATH%
     echo @ECHO OFF > %BAT_FILE%
-    echo SET mypath=%%~dp0 >> %BAT_FILE%
-    echo start /B /WAIT %%mypath:~0,-1%%/windows/main.exe >> %BAT_FILE%
+    echo start /B /WAIT windows/main.exe >> %BAT_FILE%
     GOTO DONE
 
 :linux

--- a/demo/text-to-audio/build.bat
+++ b/demo/text-to-audio/build.bat
@@ -15,8 +15,7 @@ SET SH_FILE=%BIN_FOLDER%\run.sh
 
 :BAT_WINDOWS
     echo @ECHO OFF > %BAT_FILE%
-    echo SET mypath=%%~dp0 >> %BAT_FILE%
-    echo start /B /WAIT python %%mypath:~0,-1%%/main.py >> %BAT_FILE%
+    echo start /B /WAIT python main.py >> %BAT_FILE%
 
 :SH_LINUX
 	echo #!/bin/bash > %SH_FILE%

--- a/game/play/snake/Makefile
+++ b/game/play/snake/Makefile
@@ -18,8 +18,7 @@ sh-unix:
 
 bat-windows:
 	echo '@ECHO OFF' > $(BAT)
-	echo 'SET mypath=%~dp0' >> $(BAT)
-	echo 'start /B /WAIT %mypath:~0,-1%/$(BIN_NAME)' >> $(BAT)
+	echo 'start /B /WAIT $(BIN_NAME)' >> $(BAT)
 
 docker:
 	cp Dockerfile set_umask.sh $(BIN_FOLDER)

--- a/game/play/snake/build.bat
+++ b/game/play/snake/build.bat
@@ -16,8 +16,7 @@ SET ENTRY_POINT=main.ps1
   
 :BAT_WINDOWS
   echo @ECHO OFF > %BAT_FILE%
-  echo SET mypath=%%~dp0 >> %BAT_FILE%
-  echo Powershell.exe -executionpolicy remotesigned -File %%mypath:~0,-1%%%ENTRY_POINT% >> %BAT_FILE%
+  echo Powershell.exe -executionpolicy remotesigned -File %ENTRY_POINT% >> %BAT_FILE%
 
 :SH_LINUX
     echo #!/bin/sh > %SH_FILE%

--- a/game/roll/dice/build.bat
+++ b/game/roll/dice/build.bat
@@ -14,8 +14,7 @@ SET SH_FILE=%BIN_FOLDER%\run.sh
 
 :BAT_WINDOWS
     echo @ECHO OFF > %BAT_FILE%
-    echo SET mypath=%%~dp0 >> %BAT_FILE%
-    echo start /B /WAIT python %%mypath:~0,-1%%/main.py >> %BAT_FILE%
+    echo start /B /WAIT python main.py >> %BAT_FILE%
 
 :SH_LINUX
     echo python "$(dirname "$0")"/main.py > %SH_FILE%


### PR DESCRIPTION
<!--
Customized from the template
(https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-formulas/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

<!-- markdownlint-disable MD018 -->

# Pull Request

## What I did
Fixed the path issue with composite user names on Windows platform. It's the same issue as reported in here https://github.com/ZupIT/ritchie-formulas/issues/231

## How I did it
Removing all occurrences of `%%mypath:~0,-1%%` and `%%mypath:~0,-1%%/`.
Also deleted the line `echo SET mypath=%%~dp0 >> %BAT_FILE%`.

## How to verify it
Create any formula on the Windows platform, where the user has a composite name such as "John Doe".

## What kind of change does this PR make

- [ ] Major
- [ ] Minor
- [x] Patch

<!--
See: https://semver.org/
-->

## Description for the changelog

Fixes the Windows "path not found" error.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
