### PR TITLE
Fixing easy mode broked in the hangman

### DIFF
--- a/game/play/hangman/config.json
+++ b/game/play/hangman/config.json
@@ -3,7 +3,7 @@
   "inputs": [
     {
       "items": [
-        "Database (easy)",
+        "Databases (easy)",
         "Programming languages (medium)",
         "Frameworks (hard)"
       ],


### PR DESCRIPTION
<!-- markdownlint-disable MD018 -->

# Pull Request

## What I did
Fixed the game hangman easy mode. If easy mode is selected through Ritchie, the referred variable is incorrect.
## How I did it
n/a
## How to verify it
Run through Ritchie
## What kind of change does this PR make

- [ ] Major
- [ ] Minor
- [x] Patch

## Description for the changelog
Fix for hangman easy mode.

