### PR TITLE
Fix/readme add demo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains the demonstration formulas which can be executed by the
 3. Add the [ritchie-formulas-demo repository](https://github.com/ZupIT/ritchie-formulas-demo) using the **RIT ADD REPO** command or through the command line below:
 
 ```bach
-echo '{"provider":"Github", "name":"demo", "version":"2.0.0", "url":"https://github.com/ZupIT/ritchie-formulas-demo", "token": null, "priority":"1"}' | rit add repo --stdin
+echo '{"provider":"Github", "name":"demo", "url":"https://github.com/ZupIT/ritchie-formulas-demo" "priority":"1"}' | rit add repo --stdin
 ```
 
 ## Full Documentation

--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ This repository contains the demonstration formulas which can be executed by the
 3. Add the [ritchie-formulas-demo repository](https://github.com/ZupIT/ritchie-formulas-demo) using the **RIT ADD REPO** command or through the command line below:
 
 ```bach
-<<<<<<< HEAD
 echo '{"provider":"Github", "name":"demo", "url":"https://github.com/ZupIT/ritchie-formulas-demo" "priority":"1"}' | rit add repo --stdin
-=======
-echo '{"provider":"Github", "name":"demo", "version":"2.1.1", "url":"https://github.com/ZupIT/ritchie-formulas-demo", "token": null, "priority":1}' | rit add repo --stdin
->>>>>>> upstream/master
 ```
 
 ## Full Documentation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains the demonstration formulas which can be executed by the
 3. Add the [ritchie-formulas-demo repository](https://github.com/ZupIT/ritchie-formulas-demo) using the **RIT ADD REPO** command or through the command line below:
 
 ```bach
-echo '{"provider":"Github", "name":"demo", "url":"https://github.com/ZupIT/ritchie-formulas-demo" "priority":1}' | rit add repo --stdin
+echo '{"provider":"Github", "name":"demo", "url":"https://github.com/ZupIT/ritchie-formulas-demo", "priority":1}' | rit add repo --stdin
 ```
 
 ## Full Documentation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains the demonstration formulas which can be executed by the
 3. Add the [ritchie-formulas-demo repository](https://github.com/ZupIT/ritchie-formulas-demo) using the **RIT ADD REPO** command or through the command line below:
 
 ```bach
-echo '{"provider":"Github", "name":"demo", "url":"https://github.com/ZupIT/ritchie-formulas-demo" "priority":"1"}' | rit add repo --stdin
+echo '{"provider":"Github", "name":"demo", "url":"https://github.com/ZupIT/ritchie-formulas-demo" "priority":1}' | rit add repo --stdin
 ```
 
 ## Full Documentation


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

### Description
<!-- What are the reasons and motivation of this PR -->

- With the update of the `rit add repo` command on the 2.5.0 ritchie version, this command is now generic and won't need to be updated after each ritchie-formulas-demo release.

### How to verify it

Executing the command below (after upgrading to 2.5.0 version):

```bash
echo '{"provider":"Github", "name":"demo", "url":"https://github.com/ZupIT/ritchie-formulas-demo", "priority":1}' | rit add repo --stdin
```